### PR TITLE
fix(core): guard against null client in IoRedisAdapter.doDisconnect

### DIFF
--- a/packages/core/src/driver/infrastructure/ioredis.adapter.ts
+++ b/packages/core/src/driver/infrastructure/ioredis.adapter.ts
@@ -92,8 +92,9 @@ export class IoRedisAdapter extends BaseRedisDriver {
     try {
       await this.client.quit();
     } catch {
-      // Force disconnect on error
-      this.client.disconnect();
+      // Force disconnect on error. Guard against null in case a concurrent
+      // error/reconnect handler cleared the client between quit() and this catch.
+      this.client?.disconnect();
     } finally {
       this.client = null;
     }

--- a/packages/core/test/unit/ioredis.adapter.spec.ts
+++ b/packages/core/test/unit/ioredis.adapter.spec.ts
@@ -1047,5 +1047,24 @@ describe('IoRedisAdapter', () => {
       const adapter = new IoRedisAdapter(config);
       await expect(adapter.disconnect()).resolves.not.toThrow();
     });
+
+    it('should not throw when client is nulled between quit rejection and catch block', async () => {
+      // Simulates a concurrent handler nulling the client while quit() is awaited.
+      const { adapter, mockClient } = createConnectedAdapter(
+        {},
+        {
+          quit: vi.fn().mockImplementation(async () => {
+            // Concurrent handler nulls the internal client reference
+            (adapter as unknown as { client: unknown }).client = null;
+            throw new Error('Connection lost during quit');
+          }),
+          disconnect: vi.fn(),
+        },
+      );
+
+      await expect(adapter.disconnect()).resolves.not.toThrow();
+      expect(mockClient.quit).toHaveBeenCalled();
+      expect(adapter.getClient()).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Description

Fixes a null-pointer crash in `IoRedisAdapter.doDisconnect` when a concurrent error or reconnect handler nulls the internal client between the rejected `quit()` and the catch block.

Reproduces reliably during NestJS lifecycle tear-down (`app.close()` →  `onModuleDestroy` → `closeAll`), where lifecycle hooks fire in parallel.

## Related Issue

<!-- Link to issue: Fixes #123 -->

## Checklist

- [X] Tests added or updated
- [X] `npm test` passes
- [X] `npm run typecheck` passes
- [X] `npm run lint` passes
- [X] Documentation updated (if public API changed)
- [X] Commit messages follow Conventional Commits
