### PR TITLE
Feat/client config username

### DIFF
--- a/packages/core/src/driver/infrastructure/ioredis.adapter.ts
+++ b/packages/core/src/driver/infrastructure/ioredis.adapter.ts
@@ -151,6 +151,7 @@ export class IoRedisAdapter extends BaseRedisDriver {
     const options: RedisOptions = {
       host: config.host ?? 'localhost',
       port: config.port ?? 6379,
+      username: config.username,
       password: config.password,
       db: config.db ?? 0,
       keyPrefix: config.keyPrefix,
@@ -189,6 +190,7 @@ export class IoRedisAdapter extends BaseRedisDriver {
 
     const options: ClusterOptions = {
       redisOptions: {
+        username: config.username,
         password: config.password,
         db: config.db ?? 0,
         keyPrefix: config.keyPrefix,
@@ -218,6 +220,7 @@ export class IoRedisAdapter extends BaseRedisDriver {
     const options: RedisOptions = {
       sentinels: config.sentinels,
       name: config.name,
+      username: config.username,
       password: config.password,
       db: config.db ?? 0,
       keyPrefix: config.keyPrefix,

--- a/packages/core/src/driver/infrastructure/node-redis.adapter.ts
+++ b/packages/core/src/driver/infrastructure/node-redis.adapter.ts
@@ -107,7 +107,7 @@ export class NodeRedisAdapter extends BaseRedisDriver {
         await (this.client as RedisSentinelType).close();
       } else {
         // Single and cluster clients have quit()
-        await (this.client as RedisClientType | RedisClusterType).quit();
+        await this.client.quit();
       }
     } catch {
       // Force disconnect on error
@@ -134,8 +134,7 @@ export class NodeRedisAdapter extends BaseRedisDriver {
       if (this.isSentinel) {
         // Sentinel uses .use() to get a client from the pool
         return await (this.client as RedisSentinelType).use(async (client) => {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return await (client as any).sendCommand([command, ...prefixedArgs]);
+          return await client.sendCommand([command, ...prefixedArgs]);
         });
       }
 
@@ -166,7 +165,7 @@ export class NodeRedisAdapter extends BaseRedisDriver {
       return new NodeRedisSentinelPipelineAdapter(this.client as RedisSentinelType, this.keyPrefix);
     }
 
-    return new NodeRedisPipelineAdapter(this.client as RedisClientType | RedisClusterType, this.keyPrefix);
+    return new NodeRedisPipelineAdapter(this.client, this.keyPrefix);
   }
 
   protected createMulti(): IMulti {
@@ -178,7 +177,7 @@ export class NodeRedisAdapter extends BaseRedisDriver {
       return new NodeRedisSentinelMultiAdapter(this.client as RedisSentinelType, this.keyPrefix);
     }
 
-    return new NodeRedisMultiAdapter(this.client as RedisClientType | RedisClusterType, this.keyPrefix);
+    return new NodeRedisMultiAdapter(this.client, this.keyPrefix);
   }
 
   /**
@@ -316,6 +315,7 @@ export class NodeRedisAdapter extends BaseRedisDriver {
         connectTimeout: config.connectTimeout ?? 10000,
         reconnectStrategy: config.retryStrategy ? (retries) => config.retryStrategy?.(retries) ?? false : this.getDefaultReconnectStrategy(),
       },
+      username: config.username,
       password: config.password,
       database: config.db ?? 0,
       commandsQueueMaxLength: config.enableOfflineQueue === false ? 0 : undefined,
@@ -350,6 +350,7 @@ export class NodeRedisAdapter extends BaseRedisDriver {
         },
       })),
       defaults: {
+        username: config.username,
         password: config.password,
         database: config.db ?? 0,
         socket: {
@@ -408,6 +409,7 @@ export class NodeRedisAdapter extends BaseRedisDriver {
 
     // Node client options (for connecting to actual Redis nodes)
     const nodeClientOptions: RedisClientOptions = {
+      username: sentinelConfig.username,
       password: sentinelConfig.password,
       database: sentinelConfig.db ?? 0,
       socket: {
@@ -466,7 +468,7 @@ export class NodeRedisAdapter extends BaseRedisDriver {
 
     await sentinel.connect();
 
-    return sentinel as RedisSentinelType;
+    return sentinel;
   }
 
   /**
@@ -478,7 +480,7 @@ export class NodeRedisAdapter extends BaseRedisDriver {
         await (this.client as RedisSentinelType)?.close();
       } else if (this.client) {
         // Single and cluster clients have disconnect()
-        await (this.client as RedisClientType | RedisClusterType).disconnect();
+        await this.client.disconnect();
       }
     } catch {
       // Ignore disconnect errors
@@ -852,8 +854,7 @@ class NodeRedisSentinelPipelineAdapter implements IPipeline {
       const multi = client.multi();
 
       for (const { command, args } of this.commands) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (multi as any).addCommand([command, ...args.map(String)]);
+        multi.addCommand([command, ...args.map(String)]);
       }
 
       try {

--- a/packages/core/src/plugin/domain/interfaces/plugin-context.interface.ts
+++ b/packages/core/src/plugin/domain/interfaces/plugin-context.interface.ts
@@ -119,6 +119,7 @@ export interface IRedisXConfig {
 export interface IClientConfig {
   host?: string;
   port?: number;
+  username?: string;
   password?: string;
   db?: number;
   keyPrefix?: string;

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -12,6 +12,11 @@ import { IRedisXPlugin } from '../plugin/domain/interfaces';
  */
 export interface IBaseConnectionConfig {
   /**
+   * Username for authentication (Redis 6.0+).
+   */
+  username?: string;
+
+  /**
    * Password for authentication.
    */
   password?: string;

--- a/packages/core/test/integration/node-redis/node-redis.integration.spec.ts
+++ b/packages/core/test/integration/node-redis/node-redis.integration.spec.ts
@@ -108,6 +108,51 @@ describe('Node-Redis Driver Integration', () => {
     });
   });
 
+  describe('Username Authentication', () => {
+    const username = `testuser:${Date.now()}`;
+    const password = 'P@ssw0rd123!';
+
+    afterAll(async () => {
+      try {
+        await (driver as any).executeCommand('ACL', 'DELUSER', username);
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    it('should authenticate using username and password', async () => {
+      // Given
+      await (driver as any).executeCommand('ACL', 'SETUSER', username, 'on', `>${password}`, '~*', '+@all');
+
+      const authConfig: ISingleConnectionConfig = {
+        type: 'single',
+        host: process.env.REDIS_HOST || 'localhost',
+        port: parseInt(process.env.REDIS_PORT || '6379', 10),
+        username,
+        password,
+        connectTimeout: 10000,
+      };
+
+      const authDriver = createDriver(authConfig, { type: 'node-redis' });
+
+      try {
+        await authDriver.connect();
+
+        // When
+        const whoami = await (authDriver as any).executeCommand('ACL', 'WHOAMI');
+        const result = await authDriver.ping();
+
+        // Then
+        expect(String(whoami)).toBe(username);
+        expect(result).toBe('PONG');
+      } finally {
+        if (authDriver.isConnected()) {
+          await authDriver.disconnect();
+        }
+      }
+    });
+  });
+
   describe('Set Options', () => {
     it('should set with expiration (EX)', async () => {
       // Given

--- a/packages/core/test/integration/redis.integration.spec.ts
+++ b/packages/core/test/integration/redis.integration.spec.ts
@@ -28,7 +28,7 @@ describeIntegration('Redis Integration Tests', () => {
   };
 
   beforeAll(async () => {
-    driver = createDriver(config, 'ioredis');
+    driver = createDriver(config, { type: 'ioredis' });
     await driver.connect();
   });
 
@@ -52,6 +52,51 @@ describeIntegration('Redis Integration Tests', () => {
 
       // Then
       expect(connected).toBe(true);
+    });
+  });
+
+  describe('Username Authentication', () => {
+    const username = `testuser:${Date.now()}`;
+    const password = 'P@ssw0rd123!';
+
+    afterAll(async () => {
+      try {
+        await (driver as any).executeCommand('ACL', 'DELUSER', username);
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    it('should authenticate using username and password', async () => {
+      // Given
+      await (driver as any).executeCommand('ACL', 'SETUSER', username, 'on', `>${password}`, '~*', '+@all');
+
+      const authConfig: ISingleConnectionConfig = {
+        type: 'single',
+        host: process.env.REDIS_HOST || 'localhost',
+        port: parseInt(process.env.REDIS_PORT || '6379', 10),
+        username,
+        password,
+        db: 0,
+      };
+
+      const authDriver = createDriver(authConfig, { type: 'ioredis' });
+
+      try {
+        await authDriver.connect();
+
+        // When
+        const whoami = await (authDriver as any).executeCommand('ACL', 'WHOAMI');
+        const result = await authDriver.ping();
+
+        // Then
+        expect(String(whoami)).toBe(username);
+        expect(result).toBe('PONG');
+      } finally {
+        if (authDriver.isConnected()) {
+          await authDriver.disconnect();
+        }
+      }
     });
   });
 
@@ -389,7 +434,7 @@ describeIntegration('Redis Integration Tests', () => {
 
       // When - iterate through all scan results (SCAN doesn't guarantee all keys in one call)
       const allKeys: string[] = [];
-      let cursor = '0';
+      let cursor = 0;
       do {
         const result = await driver.scan(cursor, {
           match: `${prefix}:*`,
@@ -398,9 +443,9 @@ describeIntegration('Redis Integration Tests', () => {
         expect(result).toBeDefined();
         expect(Array.isArray(result)).toBe(true);
         expect(result).toHaveLength(2);
-        cursor = result[0];
+        cursor = Number(result[0]);
         allKeys.push(...(result[1] as string[]));
-      } while (cursor !== '0');
+      } while (cursor !== 0);
 
       // Then
       expect(allKeys.length).toBeGreaterThan(0);

--- a/packages/core/test/unit/ioredis.adapter.spec.ts
+++ b/packages/core/test/unit/ioredis.adapter.spec.ts
@@ -113,6 +113,19 @@ describe('IoRedisAdapter', () => {
       expect(adapter).toBeInstanceOf(IoRedisAdapter);
     });
 
+    it('should handle ACL authentication with username', () => {
+      const config: ConnectionConfig = {
+        type: 'single',
+        host: 'redis.example.com',
+        port: 6379,
+        username: 'app-user',
+        password: 'secure-password',
+        db: 0,
+      };
+      const adapter = new IoRedisAdapter(config);
+      expect(adapter).toBeInstanceOf(IoRedisAdapter);
+    });
+
     it('should handle cluster configuration with options', () => {
       const config: ConnectionConfig = {
         type: 'cluster',
@@ -121,6 +134,7 @@ describe('IoRedisAdapter', () => {
           { host: 'localhost', port: 7001 },
           { host: 'localhost', port: 7002 },
         ],
+        username: 'app-user',
         password: 'secret',
         db: 0,
         clusterOptions: {
@@ -143,6 +157,7 @@ describe('IoRedisAdapter', () => {
           { host: 'localhost', port: 26380 },
         ],
         name: 'mymaster',
+        username: 'app-user',
         password: 'secret',
         db: 0,
         sentinelOptions: {

--- a/packages/core/test/unit/node-redis.adapter.spec.ts
+++ b/packages/core/test/unit/node-redis.adapter.spec.ts
@@ -649,11 +649,31 @@ describe('NodeRedisAdapter', () => {
       expect(adapter).toBeInstanceOf(NodeRedisAdapter);
     });
 
+    it('should apply ACL authentication with username', () => {
+      // Given
+      const config: ConnectionConfig = {
+        type: 'single',
+        host: 'redis.example.com',
+        port: 6379,
+        username: 'app-user',
+        password: 'secure-password',
+        db: 0,
+      };
+
+      // When
+      const adapter = new NodeRedisAdapter(config);
+
+      // Then
+      expect(adapter).toBeInstanceOf(NodeRedisAdapter);
+    });
+
     it('should apply cluster options', () => {
       // Given
       const config: ConnectionConfig = {
         type: 'cluster',
         nodes: [{ host: 'localhost', port: 7000 }],
+        username: 'app-user',
+        password: 'secret',
         clusterOptions: {
           maxRedirections: 32,
           scaleReads: 'slave',
@@ -673,6 +693,7 @@ describe('NodeRedisAdapter', () => {
         type: 'sentinel',
         sentinels: [{ host: 'localhost', port: 26379 }],
         name: 'mymaster',
+        username: 'app-user',
         password: 'secret',
       };
 

--- a/website/en/guide/architecture/connection-management.md
+++ b/website/en/guide/architecture/connection-management.md
@@ -130,6 +130,88 @@ Prevent connection drops in cloud environments:
 }
 ```
 
+## Authentication
+
+### Basic Authentication (Redis 5.x and earlier)
+
+```typescript
+{
+  host: 'redis',
+  port: 6379,
+  password: process.env.REDIS_PASSWORD,
+}
+```
+
+### ACL Authentication (Redis 6.0+)
+
+Redis 6.0 introduced ACL (Access Control Lists) with username/password authentication:
+
+```typescript
+{
+  host: 'redis.example.com',
+  port: 6379,
+  username: process.env.REDIS_USERNAME,  // ACL username
+  password: process.env.REDIS_PASSWORD,  // ACL password
+}
+```
+
+### Server-Side ACL Configuration
+
+```
+# redis.conf or ACL file
+user app-user on >secure-password ~cache:* ~lock:* +@read +@write -@admin
+user migration-user on >migration-password ~* +@all
+```
+
+### Role-Based Access Pattern
+
+```typescript
+// Application with restricted permissions
+RedisModule.forRoot({
+  clients: {
+    app: {
+      host: 'redis',
+      port: 6379,
+      username: 'app-user',
+      password: process.env.APP_REDIS_PASSWORD,
+    },
+  },
+})
+
+// Admin connection with full permissions
+const adminClient = createClient({
+  host: 'redis',
+  port: 6379,
+  username: 'admin-user',
+  password: process.env.ADMIN_REDIS_PASSWORD,
+});
+```
+
+### Secrets Management
+
+```typescript
+// AWS Secrets Manager example
+import { SecretsManager } from '@aws-sdk/client-secrets-manager';
+
+async function getRedisCredentials() {
+  const sm = new SecretsManager({});
+  const secret = await sm.getSecretValue({ 
+    SecretId: 'redis-credentials' 
+  });
+  return JSON.parse(secret.SecretString);
+}
+
+// Use in module
+RedisModule.forRootAsync({
+  useFactory: async () => {
+    const { host, port, username, password } = await getRedisCredentials();
+    return {
+      clients: { host, port, username, password },
+    };
+  },
+})
+```
+
 ## TLS Configuration
 
 ```typescript


### PR DESCRIPTION
## Description

This PR adds support for the username connection parameter to the redis client configs (`ioredis` and `node-redis` drivers).

## Related Issue

<!-- Link to issue: Fixes #123 -->

## Checklist

- [x] Tests added or updated
- [x] `npm test` passes
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Documentation updated (if public API changed)
- [x] Commit messages follow Conventional Commits
